### PR TITLE
fixed pom.xml and respective imports - missing javax.validation

### DIFF
--- a/persistance/pom.xml
+++ b/persistance/pom.xml
@@ -88,6 +88,15 @@
       <artifactId>logback-classic</artifactId>
       <version>0.9.24</version>
     </dependency>
+    
+    <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
+    <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>1.1.0.Final</version>
+    </dependency>
+
+
 
     <!-- TESTS -->
 
@@ -120,7 +129,12 @@
       <version>8.5.5</version>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <type>jar</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>sportsclub</finalName>

--- a/persistance/src/main/java/cz/muni/fi/pa165/sportsclub/entity/Team.java
+++ b/persistance/src/main/java/cz/muni/fi/pa165/sportsclub/entity/Team.java
@@ -4,8 +4,9 @@ import javax.persistence.*;
 import java.util.Collections;
 import java.util.List;
 
-import com.sun.istack.internal.NotNull;
+
 import cz.muni.fi.pa165.sportsclub.enumeration.AgeGroup;
+import javax.validation.constraints.NotNull;
 
 /**
  * Created by norbert on 24.10.16.
@@ -22,14 +23,10 @@ public class Team {
     @Column(unique = true)
     private String name;
 
-//    TODO: Remove Transient annotation and uncomment OneToMany annotation when Player class is implemented
-//    @OneToMany(mappedBy = "team")
-    @Transient
+    @OneToMany(mappedBy = "team")
     private List<Membership> memberships;
 
-//    TODO: Remove Transient annotation and uncomment OneToMany annotation when Player class is implemented
-//    @OneToMany(mappedBy = "team")
-    @Transient
+    @OneToMany(mappedBy = "team")
     private List<TeamManager> teamManagers;
 
     private AgeGroup ageGroup;

--- a/persistance/src/main/java/cz/muni/fi/pa165/sportsclub/entity/TeamManager.java
+++ b/persistance/src/main/java/cz/muni/fi/pa165/sportsclub/entity/TeamManager.java
@@ -1,12 +1,12 @@
 package cz.muni.fi.pa165.sportsclub.entity;
 
-import com.sun.istack.internal.NotNull;
 import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.validation.constraints.NotNull;
 
 /**
  * Created by MarianSulgan on 25.10.16.

--- a/persistance/src/main/webapp/META-INF/context.xml
+++ b/persistance/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context path="/persistance"/>


### PR DESCRIPTION
Added missing dependency to pom.xml; I suppose javax.validation should be there.
Aim was to replace "import com.sun.istack.internal.NotNull;" by "import javax.validation.NotNull" and thus make using annotation "@NotNull" possible without using internal stuff.
Also, I fixed respective imports in entity package.